### PR TITLE
SRE-302: increase max header size so we don't get HTTP 431

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>2.9.3</version>
+    <version>2.9.3-token</version>
     <name>Spark</name>
     <description>A micro framework for creating web applications in Kotlin and Java 8 with minimal effort</description>
     <url>http://www.sparkjava.com</url>

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -109,6 +109,7 @@ public class SocketConnectorFactory {
 
     private static HttpConnectionFactory createHttpConnectionFactory() {
         HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setRequestHeaderSize(60 * 1024);
         httpConfig.setSecureScheme("https");
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         return new HttpConnectionFactory(httpConfig);


### PR DESCRIPTION
[This ui test](https://github.com/tokenio/ui-integration-tests/blob/master/features/afterbanks_aisp_access.feature#L25) fails when Istio is used as Ingress.

The reason is that the user at Evo Bank has many different bank accounts, that leads to big request headers total size. [Sparkjava](http://sparkjava.com/) is using [Jetty](https://www.eclipse.org/jetty/) embedded server and doesn't really allow to change [HttpConfiguration defaults](https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L60).

So when we run this test without Istio we are already close to maximum headers size, but Istio adds more headers so we get ["Header too large 8193>8192" errors](https://logs-eu-west-1.internal.token.io/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2020-10-15T02:24:11.812Z',mode:absolute,to:'2020-10-15T04:57:20.410Z'))&_a=(columns:!(service,level,message),index:'15d21b70-87f1-11e9-9f71-efeb4a5050b2',interval:auto,query:(language:lucene,query:%228193%3E8192%22),sort:!('@timestamp',desc)))

I've increased max headers size to 60Kb [which is default for Envoy](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto).

The intention is to use this branch in lib-service and then in bank-integration.